### PR TITLE
✨로그인 access token을 datastore을 이용해서 저장

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,7 +103,8 @@ dependencies {
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.0")
 
 
-
+    // token을 저장할 preferences datastore
+    implementation ("androidx.datastore:datastore-preferences:1.0.0")
 
 
 

--- a/app/src/main/java/com/proj/movieappreciate/config/App.kt
+++ b/app/src/main/java/com/proj/movieappreciate/config/App.kt
@@ -2,6 +2,8 @@ package com.proj.movieappreciate.config
 
 import android.app.Application
 import android.content.Context
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.kakao.sdk.common.KakaoSdk
@@ -35,6 +37,14 @@ class App : Application() {
     private var appContext: Context? = null
     lateinit var sharedPreferences: SharedPreferencesUtil
     companion object {
+
+        // 인스턴스화할 preferences datastore의 이름
+        val USER_PREFERENCES_NAME = "user_preferences"
+        val Context.datastore by  preferencesDataStore(
+            name = USER_PREFERENCES_NAME
+        )
+
+        val ACCESS_TOKEN_KEY = stringPreferencesKey("user_access_token")
 
 
         const val SHARED_PREFERENCES_NAME = "SHARED_PREFERENCE"

--- a/app/src/main/java/com/proj/movieappreciate/data/dataSource/model/LoginResponse.kt
+++ b/app/src/main/java/com/proj/movieappreciate/data/dataSource/model/LoginResponse.kt
@@ -1,5 +1,10 @@
 package com.proj.movieappreciate.data.dataSource.model
 
 data class LoginResponse(
-    val token : String
+    val uid: String,
+    val type: String,
+    val userId: String,
+    val accessToken: String,
+    val refreshToken: String
 )
+

--- a/app/src/main/java/com/proj/movieappreciate/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/proj/movieappreciate/data/repository/AuthRepository.kt
@@ -1,14 +1,21 @@
 package com.proj.movieappreciate.data.repository
 
+import android.content.Context
 import android.util.Log
-import com.proj.movieappreciate.data.dataSource.model.UserDTO
 import com.proj.movieappreciate.data.dataSource.model.LoginResponse
 import com.proj.movieappreciate.data.dataSource.model.SignUpResponse
 import com.proj.movieappreciate.data.dataSource.remote.AuthRemoteDataSource
-import com.proj.movieappreciate.data.dataSource.remote.retrofit.RemoteDataSource
+import com.proj.movieappreciate.ui.login.data.UserPreferencesRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.internal.userAgent
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
-class AuthRepository @Inject constructor(private val remoteDataSource: AuthRemoteDataSource) {
+class AuthRepository @Inject constructor(
+    private val remoteDataSource: AuthRemoteDataSource,
+    val userPreferencesRepository: UserPreferencesRepository
+) {
+
     class SignUpException : Exception("SignUp")
     suspend fun signUp(uid : String, type : String, profileURL : String): Result<SignUpResponse> {
         return try {
@@ -28,7 +35,11 @@ class AuthRepository @Inject constructor(private val remoteDataSource: AuthRemot
         return try {
             val response = remoteDataSource.login(uid, type)
             if (response.isSuccessful) {
-                Log.d("로그인 성공", response.headers().toString())
+                //todo : datastore에 access token 저장해주기
+                Log.d("로그인 액세스 토큰", response.body()?.accessToken.toString())
+                userPreferencesRepository.saveUserAccessToken(response.body()?.accessToken.toString())
+                Log.d("로그인 데이터스토어", userPreferencesRepository.getAccessToken().toString())
+
                 Result.success(response.body()!!)
             } else {
                 if(response.code() == 401){

--- a/app/src/main/java/com/proj/movieappreciate/ui/LoginActivity.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/LoginActivity.kt
@@ -163,6 +163,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
         }
         loginActivityViewModel.loginResponse.observe(this@LoginActivity) {
             val data = it.getOrNull()
+            Log.d("로그인",data.toString())
             if (data != null){
                 Toast.makeText(this@LoginActivity, "로그인 완료", Toast.LENGTH_LONG).show()
                 Log.d(TAG, "init: 로그인 ${it}")
@@ -213,9 +214,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
             is GoogleIdTokenCredential -> {
                 try {
                     val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
-                    // GoogleIdTokenCredential으로 할 수 있는 추가 작업 수행
-                    googleIdTokenCredential.id
-                    googleIdTokenCredential.data
+
                     loginActivityViewModel.login(uid = googleIdTokenCredential.id, type = "google", profileURL = "")
 
                 } catch (e: GoogleIdTokenParsingException) {

--- a/app/src/main/java/com/proj/movieappreciate/ui/login/data/LoginDataSource.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/login/data/LoginDataSource.kt
@@ -1,7 +1,8 @@
-package com.proj.movieappreciate.ui.data
+package com.proj.movieappreciate.ui.login.data
 
-import com.proj.movieappreciate.ui.data.model.LoggedInUser
+import com.proj.movieappreciate.ui.login.data.model.LoggedInUser
 import java.io.IOException
+import java.util.UUID
 
 /**
  * Class that handles authentication w/ login credentials and retrieves user information.
@@ -11,7 +12,7 @@ class LoginDataSource {
     fun login(username: String, password: String): Result<LoggedInUser> {
         try {
             // TODO: handle loggedInUser authentication
-            val fakeUser = LoggedInUser(java.util.UUID.randomUUID().toString(), "Jane Doe")
+            val fakeUser = LoggedInUser(UUID.randomUUID().toString(), "Jane Doe")
             return Result.Success(fakeUser)
         } catch (e: Throwable) {
             return Result.Error(IOException("Error logging in", e))

--- a/app/src/main/java/com/proj/movieappreciate/ui/login/data/LoginRepository.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/login/data/LoginRepository.kt
@@ -1,6 +1,6 @@
-package com.proj.movieappreciate.ui.data
+package com.proj.movieappreciate.ui.login.data
 
-import com.proj.movieappreciate.ui.data.model.LoggedInUser
+import com.proj.movieappreciate.ui.login.data.model.LoggedInUser
 
 /**
  * Class that requests authentication and user information from the remote data source and

--- a/app/src/main/java/com/proj/movieappreciate/ui/login/data/Result.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/login/data/Result.kt
@@ -1,4 +1,4 @@
-package com.proj.movieappreciate.ui.data
+package com.proj.movieappreciate.ui.login.data
 
 /**
  * A generic class that holds a value with its loading status.

--- a/app/src/main/java/com/proj/movieappreciate/ui/login/data/UserPreferences.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/login/data/UserPreferences.kt
@@ -1,0 +1,6 @@
+package com.proj.movieappreciate.ui.login.data
+
+data class UserPreferences(
+    val accessToken: String,
+    val refreshToken:String
+)

--- a/app/src/main/java/com/proj/movieappreciate/ui/login/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/login/data/UserPreferencesRepository.kt
@@ -1,0 +1,63 @@
+package com.proj.movieappreciate.ui.login.data
+
+import android.content.Context
+import android.os.Build.VERSION_CODES.P
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.proj.movieappreciate.config.App.Companion.ACCESS_TOKEN_KEY
+import com.proj.movieappreciate.config.App.Companion.datastore
+import com.proj.movieappreciate.data.dataSource.model.LoginResponse
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+class UserPreferencesRepository @Inject constructor(
+    @ApplicationContext context: Context) {
+
+    private val datastore = context.datastore
+
+    val userAccessTokenFlow: Flow<String> =datastore.data
+        .catch {
+            exception -> if(exception is IOException) {
+                emit(emptyPreferences())
+        }
+            else{
+                throw exception
+        }
+        }
+        .map {
+                preferences -> preferences[ACCESS_TOKEN_KEY] ?: ""
+        }
+
+
+    fun getAccessToken():Flow<String?> {
+        return datastore.data.map {
+            preferences ->preferences[ACCESS_TOKEN_KEY]
+        }
+
+    }
+    suspend fun saveUserAccessToken(userAccessToken : String) {
+        datastore.edit { preferences ->
+            preferences[ACCESS_TOKEN_KEY] = userAccessToken
+        }
+
+    }
+
+}
+
+

--- a/app/src/main/java/com/proj/movieappreciate/ui/login/data/model/LoggedInUser.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/login/data/model/LoggedInUser.kt
@@ -1,4 +1,4 @@
-package com.proj.movieappreciate.ui.data.model
+package com.proj.movieappreciate.ui.login.data.model
 
 /**
  * Data class that captures user information for logged in users retrieved from LoginRepository

--- a/app/src/main/java/com/proj/movieappreciate/ui/viewModel/LoginActivityViewModel.kt
+++ b/app/src/main/java/com/proj/movieappreciate/ui/viewModel/LoginActivityViewModel.kt
@@ -1,5 +1,6 @@
 package com.proj.movieappreciate.ui.viewModel
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -10,6 +11,7 @@ import com.proj.movieappreciate.data.dataSource.model.LoginResponse
 import com.proj.movieappreciate.data.dataSource.model.SignUpData
 import com.proj.movieappreciate.data.dataSource.model.SignUpResponse
 import com.proj.movieappreciate.data.repository.AuthRepository
+import com.proj.movieappreciate.ui.login.data.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -39,8 +41,6 @@ class LoginActivityViewModel @Inject constructor(private val authRepository : Au
             val data = UserDTO(uid, type)
             try{
                 val result = authRepository.login(uid, type)
-                Log.d("로그인 login viewModel", result.isSuccess.toString())
-                Log.e("로그인 viewModel", "login: ${result}" )
                 if(result.isFailure){
                     if(result.exceptionOrNull() is AuthRepository.SignUpException){
                         signUp(uid, type, profileURL)
@@ -48,7 +48,7 @@ class LoginActivityViewModel @Inject constructor(private val authRepository : Au
                 }
                 else{
                     _loginResponse.value = result
-                    Log.d("로그인 login 뷰 모댈 result", "login: $result")
+                    Log.d("로그인 login 뷰 모댈 result", "login: ${_loginResponse.value}")
                 }
 
             } catch (e : Exception){

--- a/app/src/main/java/com/proj/movieappreciate/util/AppModule.kt
+++ b/app/src/main/java/com/proj/movieappreciate/util/AppModule.kt
@@ -1,4 +1,23 @@
 package com.proj.movieappreciate.util
 
-object AppModule {
+import android.content.Context
+import com.proj.movieappreciate.ui.login.data.UserPreferencesRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TokenModule {
+
+    @Singleton
+    @Provides
+    fun providesUserPreferencesRepository(@ApplicationContext context : Context) : UserPreferencesRepository {
+        return UserPreferencesRepository(context)
+    }
+
+
 }

--- a/app/src/main/java/com/proj/movieappreciate/util/RepositoryModule.kt
+++ b/app/src/main/java/com/proj/movieappreciate/util/RepositoryModule.kt
@@ -1,10 +1,11 @@
 package com.proj.movieappreciate.util
 
+import android.content.Context
 import com.proj.movieappreciate.data.dataSource.remote.AuthRemoteDataSource
 import com.proj.movieappreciate.data.dataSource.remote.ReportRemoteDataSource
-import com.proj.movieappreciate.data.dataSource.remote.retrofit.RemoteDataSource
 import com.proj.movieappreciate.data.repository.AuthRepository
 import com.proj.movieappreciate.data.repository.ReportRepository
+import com.proj.movieappreciate.ui.login.data.UserPreferencesRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,8 +18,8 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideAuthRepository(remoteDataSource: AuthRemoteDataSource): AuthRepository {
-        return AuthRepository(remoteDataSource)
+    fun provideAuthRepository(remoteDataSource: AuthRemoteDataSource,userPreferencesRepository: UserPreferencesRepository): AuthRepository {
+        return AuthRepository(remoteDataSource,userPreferencesRepository)
     }
 
     @Provides
@@ -26,4 +27,5 @@ object RepositoryModule {
     fun provideReportRepository(remoteDataSource: ReportRemoteDataSource): ReportRepository {
         return ReportRepository(remoteDataSource)
     }
+
 }


### PR DESCRIPTION
## Title

로그인 시 response로 오는 access token을 prefereces datastore을 통해 로컬 db에 저장하는 로직을 구현했어요

## What type of PR is this? 

- [x] ✨  Feature ( 새로운 기능 추가 )
- [ ] 🐛 Bug Fix ( 버그 수정 )
- [ ] 📝 Documentation Update ( 개발자 관련 문서 업데이트 )
- [ ] 🎨 Style ( 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우 )
- [ ] 🧑‍💻 Code Refactor ( 코드 리펙토링 )
- [ ] 🔥 Performance Improvements ( 성능 향상 )
- [ ] ✅ Test ( 테스트 코드, 리펙토링 테스트 코드 추가 )
- [ ] 🤖 Build  ( 빌드 )
- [ ] 🔁 CI 
- [ ] 📦 Chore (Release) (빌드 업무 수정, 패키지 매니저 수정 )
- [ ] ⏩ Revert ( 커밋을 날린 경우 )

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Issue  number and link
- Issue : #3 
 현재는 해당 에러가 발생하지 않고 있습니다! 서버 관련으로 나타났던 에러같아요! 
서버가 수정된 지금은 나타나지 않고 있어 이슈를 닫도록 하겠습니당

## Mobile & Desktop Screenshots/Recordings



## To Reviewers

jwt 토큰 로직이 완료되면 이후 코드를 구현하려 합니다! 지금은 로그인 response를 통해 받은 access token을 로컬 db에 저장하기 위해 preferences datastore을 이용했습니다

코멘트 남긴 부분위주로만 확인해주시면 될 것 같습니다! 확인되면 바로 머지해서 이후 다른 기능 구현하도록 할게요